### PR TITLE
Change reference from Anthropic to Github in README.md

### DIFF
--- a/cmd/mcpcurl/README.md
+++ b/cmd/mcpcurl/README.md
@@ -31,7 +31,7 @@ The `--stdio-server-cmd` flag is required for all commands and specifies the com
 
 ### Examples
 
-List available tools in Anthropic's MCP server:
+List available tools in Github's MCP server:
 
 ```console
 % ./mcpcurl --stdio-server-cmd "docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN mcp/github" tools --help


### PR DESCRIPTION
Noticed README for mcpurl referenced Anthropic's MCP Server when I think intent is to reference Github's - probably some copy pasta origin. Hope this doesn't need an Issue.
